### PR TITLE
harass check

### DIFF
--- a/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellQ.cs
+++ b/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellQ.cs
@@ -183,6 +183,14 @@
                             this.SpellObject.Cast(prediction.CastPosition);
                         }
                     }
+                    
+                    if (this.SpellObject.IsCharging)
+                    {
+                         if (target.Distance(ObjectManager.Player) < this.Range)
+                         {
+                             this.SpellObject.Cast(target);
+                         }
+                    }
                 }
             }
         }


### PR DESCRIPTION
without if (target.Distance(ObjectManager.Player) < this.Range) harass holds on to the charge for too long