### PR TITLE
q/e "spell weaving"

### DIFF
--- a/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellE.cs
+++ b/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellE.cs
@@ -84,7 +84,7 @@
                 {
                     if (MyMenu.RootMenu.Item("comboealways").IsActive() || 
                         this.SpellObject.IsKillable(target) || 
-                        (Misc.BlightedQuiver.Level > 0 && Misc.GetWStacks(target) >= MyMenu.RootMenu.Item("comboew.count").GetValue<Slider>().Value))
+                        (Misc.BlightedQuiver.Level > 0 && Misc.GetWStacks(target) >= MyMenu.RootMenu.Item("comboew.count").GetValue<Slider>().Value && Misc.LastQ + 1000 < Environment.TickCount))
                     {
                         if ((!MyMenu.RootMenu.Item("comboealways").IsActive()
                              && Misc.LastQ + 200 < Environment.TickCount) || this.SpellObject.IsKillable(target))

--- a/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellQ.cs
+++ b/ElVarusRevamped/ElVarusRevamped/Components/Spells/SpellQ.cs
@@ -109,7 +109,7 @@
                     {
                         if (MyMenu.RootMenu.Item("comboqalways").IsActive()
                             || Misc.QIsKillable(target, Misc.GetQCollisionsCount(target, this.SpellObject.GetPrediction(target).CastPosition)) 
-                            || (Misc.BlightedQuiver.Level > 0 && Misc.GetWStacks(target) >= MyMenu.RootMenu.Item("combow.count").GetValue<Slider>().Value))
+                            || (Misc.BlightedQuiver.Level > 0 && Misc.GetWStacks(target) >= MyMenu.RootMenu.Item("combow.count").GetValue<Slider>().Value && Misc.LastE + 1000 < Environment.TickCount)))
                         {
                             this.SpellObject.StartCharging();
                         }


### PR DESCRIPTION
the tick count check stuff needs to be in the same area as the W stack check. the issue was both spells being casted at once for the same blight check, so you add on the tick shit to the blight check and everything gucci.

3 AA -> E and Q match blight checks -> both fire at same time BAD BAD BAD
3 AA -> E and Q match blight checks -> Q has Misc.LastE + 200 < Environment.TickCount) -> Only E fires -> 3 AA -> E on CD, Q matches blight check ->Only Fires Q

WE DID IT REDDIT. Also 1 second good delay